### PR TITLE
use `path.resolve` to resolve path instead of concatenating strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function (entry, is_cli) {
 }
 
 function get_dirname_in_node_modules(){
-  var dir =  path.resolve(__dirname, '..')
+  var dir =  path.resolve(__dirname, '../../node_modules')
   var plugin_base = 'babel-plugin-'
   console.log('3babel presets path = ' + dir)
   // npm 3.x set babel in entry file

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 require("babel-polyfill")
 
 var fs = require('fs')
+var path = require('path')
 
 var is_npm_v3 = /^3/.test(require('child_process').execSync('npm -v').toString())
 
@@ -27,7 +28,7 @@ module.exports = function (entry, is_cli) {
   }
   
   var current_path = process.cwd();
-  var f = current_path + '/bin/www'
+  var f = path.resolve(current_path, 'bin/www')
 
   if (is_cli == true && entry && /^\//.test(entry)){
     f = entry
@@ -45,13 +46,13 @@ module.exports = function (entry, is_cli) {
 }
 
 function get_dirname_in_node_modules(){
-  var dir =  __dirname + '/node_modules/'
-  var plugin_dir = dir + 'babel-plugin-'
+  var dir =  path.resolve(__dirname, '..')
+  var plugin_base = 'babel-plugin-'
   console.log('3babel presets path = ' + dir)
   // npm 3.x set babel in entry file
   require('babel-core/register')({
-    plugins: [plugin_dir + 'add-module-exports', plugin_dir + 'transform-es2015-modules-commonjs'],
-    presets: [dir + 'babel-preset-es2015-node5', dir + 'babel-preset-stage-3'],
+    plugins: [path.resolve(dir, plugin_base + 'add-module-exports'), path.resolve(dir, plugin_base + 'transform-es2015-modules-commonjs')],
+    presets: [path.resolve(dir, 'babel-preset-es2015-node5'), path.resolve(dir, 'babel-preset-stage-3')],
     babelrc: false
   })  
 }
@@ -59,20 +60,18 @@ function get_dirname_in_node_modules(){
 function get_dirname_in_parent(){
   var dir =  __dirname.replace('runkoa', '')
 
-  var plugin_dir = dir + 'babel-plugin-'
-  
+  var plugin_base = 'babel-plugin-'
   
   if(is_npm_v3 === true && process.env.RUNKOA_TEST){
-    dir = dir + 'runkoa/node_modules/'
-    plugin_dir = dir + 'babel-plugin-'
+    dir = path.resolve(dir, 'runkoa/node_modules/')
   }
   
   console.log('2babel presets path = ' + dir)
   
   // npm 2.x set babel in entry file
   require('babel-core/register')({
-    plugins: [plugin_dir + 'add-module-exports', plugin_dir + 'transform-es2015-modules-commonjs'],
-    presets: [dir + 'babel-preset-es2015-node5', dir + 'babel-preset-stage-3'],
+    plugins: [path.resolve(dir, plugin_base + 'add-module-exports'), path.resolve(dir, plugin_base + 'transform-es2015-modules-commonjs')],
+    presets: [path.resolve(dir, 'babel-preset-es2015-node5'), path.resolve(dir, 'babel-preset-stage-3')],
     babelrc: false
   }) 
 }

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function (entry, is_cli) {
   }
   
   var current_path = process.cwd();
-  var f = path.resolve(current_path, 'bin/www')
+  var f = path.resolve(current_path, '/bin/www')
 
   if (is_cli == true && entry && /^\//.test(entry)){
     f = entry
@@ -46,7 +46,7 @@ module.exports = function (entry, is_cli) {
 }
 
 function get_dirname_in_node_modules(){
-  var dir =  path.resolve(__dirname, '../../node_modules')
+  var dir =  path.resolve(__dirname, 'node_modules/')
   var plugin_base = 'babel-plugin-'
   console.log('3babel presets path = ' + dir)
   // npm 3.x set babel in entry file


### PR DESCRIPTION
'/' doesn't work correctly on Windows platform when concatenating strings to generate path.
