### PR TITLE
npm4会导致不明插件的错误

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var fs = require('fs')
 var debug = require('debug')('runkoa')
 var path = require('path')
 
-var is_npm_v3 = /^3/.test(require('child_process').execSync('npm -v').toString())
+var is_npm_v3 = /^[3|4]/.test(require('child_process').execSync('npm -v').toString())
 
 /**
   cli加载的preset是一样的


### PR DESCRIPTION
npm4和npm3使用了一样的目录结构，只需要修改npm版本判断的正则表达式（第9行）